### PR TITLE
GSWA 3 additions

### DIFF
--- a/vocabularies/geosciml/boreholedrillingmethod.ttl
+++ b/vocabularies/geosciml/boreholedrillingmethod.ttl
@@ -37,7 +37,7 @@
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/auger>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/box_core>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/core_drilling>,
-        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/hydraulic_rotary_drilling>,
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/rotary_drilling>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/percussion_drilling>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/probe>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/sidewall_core>,
@@ -62,7 +62,9 @@
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/geoprobe_core>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/gravity_core>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/hand_auger>,
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/rotary_drilling>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/hydraulic_rotary_drilling>,
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/mud_rotary_drilling>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/kasten_core>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/mackereth_core>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/mackintosh_probe>,
@@ -135,14 +137,37 @@
     skos:topConceptOf <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> .
 
 
+<http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/rotary_drilling> a skos:Concept ;
+    dcterms:source "https://en.wikipedia.org/wiki/Drill"^^xsd:anyURI ;
+    rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
+    skos:definition "A drilling method using a drill stem equipped with a bit that is rotated"@en ;
+    skos:inScheme <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
+    skos:narrower 
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/hydraulic_rotary_drilling> ,
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/mud_rotary_drilling> ;
+    skos:notation "3"^^dt:LocalHierarchyKey ;
+    skos:prefLabel "rotary drilling"@en ;
+    skos:topConceptOf <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> .
+
+
 <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/hydraulic_rotary_drilling> a skos:Concept ;
     dcterms:source "https://en.wikipedia.org/wiki/Drilling_rig#Hydraulic_rotary_drilling"^^xsd:anyURI ;
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
+    skos:broader <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/rotary_drilling> ;
     skos:definition "A drilling method using a drill stem equipped with a bit that is rotated to cut and grind the rock with a fluid pumped down the stem to force cuttings up through the annular space between the stem and the wall of the hole. Oil well drilling of this type utilises tri-cone roller, carbide embedded, fixed-cutter diamond, or diamond-impregnated drill bits. This is preferred because there is no need to return intact samples to surface for assay as the objective is to reach a formation containing oil or natural gas. Sizable machinery is used, enabling depths of several kilometres to be penetrated. Rotating hollow drill pipes carry down bentonite and barite infused drilling muds to lubricate, cool, and clean the drilling bit, control downhole pressures, stabilize the wall of the borehole and remove drill cuttings."@en ;
     skos:inScheme <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
-    skos:notation "3"^^dt:LocalHierarchyKey ;
-    skos:prefLabel "hydraulic rotary drilling"@en ;
-    skos:topConceptOf <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> .
+    skos:notation "3.1"^^dt:LocalHierarchyKey ;
+    skos:prefLabel "hydraulic rotary drilling"@en .
+
+
+<http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/mud_rotary_drilling> a skos:Concept ;
+    dcterms:source "https://www.trenchlesspedia.com/definition/3681/mud-rotary-drilling"^^xsd:anyURI ;
+    rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
+    skos:broader <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/rotary_drilling> ;
+    skos:definition "Mud rotary drilling is a method for wellbore excavation. It involves the use of a spinning drill bit aided by a semi-fluid mixture known as mud. Mud rotary drilling is adaptable for a wide range of trenchless construction situations, and is considered the most versatile and common of drilling methods."@en ;
+    skos:inScheme <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
+    skos:notation "3.2"^^dt:LocalHierarchyKey ;
+    skos:prefLabel "hydraulic rotary drilling"@en .
 
 
 <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/percussion_drilling> a skos:Concept ;

--- a/vocabularies/geosciml/boreholedrillingmethod.ttl
+++ b/vocabularies/geosciml/boreholedrillingmethod.ttl
@@ -36,6 +36,7 @@
     skos:hasTopConcept <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/air_core>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/auger>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/box_core>,
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/coiled_tubing_drilling>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/core_drilling>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/rotary_drilling>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/percussion_drilling>,
@@ -53,6 +54,7 @@
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/auger>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/box_core>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/cable_tool_drilling>,
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/coiled_tubing_drilling>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/cone_penetrometer_test_probe>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/conventional_core>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/core_drilling>,
@@ -134,6 +136,17 @@
         "carotaggio"@it,
         "burenie kolonkovoe"@ru,
         "kärnborrning"@sv ;
+    skos:topConceptOf <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> .
+
+
+<http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/coiled_tubing_drilling> a skos:Concept ;
+    dcterms:source "https://en.wikipedia.org/wiki/Coiled_tubing"^^xsd:anyURI ;
+    rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
+    skos:altLabel "coiling tube drilling"@en ;
+    skos:definition "Coiled tubing drilling (CTD) is a trenchless technique that uses coiled tubing spooled on a large reel instead of metal pipes. CTD is used in both mineral and petroleum industry. In the latter, CTD is commonly used in existing wellbores for re-entry drilling or sidetracking through the production tubing, for new shallow wells, deepening conventional wells and for drilling under-balanced. Complex CTD operations, including directional drilling and cased completions, require pipe handling equipment, large diameter coiled tubing, fluid handling equipment for mixing, cleaning and recirculating, provisions for handling long bottom hole assemblies (BHA) and blowout preventer (BOP) stacks."@en ;
+    skos:inScheme <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
+    skos:notation "10"^^dt:LocalHierarchyKey ;
+    skos:prefLabel "rotary drilling"@en ;
     skos:topConceptOf <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> .
 
 

--- a/vocabularies/geosciml/boreholedrillingmethod.ttl
+++ b/vocabularies/geosciml/boreholedrillingmethod.ttl
@@ -42,7 +42,8 @@
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/percussion_drilling>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/probe>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/sidewall_core>,
-        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/sonic> ;
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/sonic>,
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/vacuum> ;
     skos:prefLabel "Borehole Drilling Method"@en .
 
 
@@ -80,6 +81,7 @@
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/sidewall_core_bullet>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/sidewall_core_mechanical>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/sonic>,
+        <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/vacuum>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/vibrocore>,
         <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/window_sampler> ;
     skos:prefLabel "Borehole Drilling Method - All Concepts"@en .
@@ -146,7 +148,7 @@
     skos:definition "Coiled tubing drilling (CTD) is a trenchless technique that uses coiled tubing spooled on a large reel instead of metal pipes. CTD is used in both mineral and petroleum industry. In the latter, CTD is commonly used in existing wellbores for re-entry drilling or sidetracking through the production tubing, for new shallow wells, deepening conventional wells and for drilling under-balanced. Complex CTD operations, including directional drilling and cased completions, require pipe handling equipment, large diameter coiled tubing, fluid handling equipment for mixing, cleaning and recirculating, provisions for handling long bottom hole assemblies (BHA) and blowout preventer (BOP) stacks."@en ;
     skos:inScheme <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
     skos:notation "10"^^dt:LocalHierarchyKey ;
-    skos:prefLabel "rotary drilling"@en ;
+    skos:prefLabel "coiled tubing drilling"@en ;
     skos:topConceptOf <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> .
 
 
@@ -444,6 +446,16 @@
     skos:inScheme <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
     skos:notation "8.2"^^dt:LocalHierarchyKey ;
     skos:prefLabel "sidewall core mechanical"@en .
+
+
+<http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/vacuum> a skos:Concept ;
+    dcterms:source "https://101sampling.com/drill-rigs/vacuum-drill/"^^xsd:anyURI ;
+    rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
+    skos:definition "Vacuum drilling is principally designed for mineral exploration drilling to provide a low cost, efficient recovery of uncontaminated drill samples. Vacuum Drilling systems comprise a vacuum pump, oil bath filter, sample separator, vacuum swivel and drive shaft adaptor to rotary drilling head. The vacuum pump can be driven either hydraulically or mechanically from the existing drill rig power pack. Alternatively, a separate independent drive source can be provided. Samples are removed from the rod string via the vacuum swivel mounted above the rotary head. Then, cuttings proceed to the two-stage sample separator for removal from the air stream, and are collected in the bulk sample flask. Separated air is then passed through the oil bath filter to be discharged from the vacuum pump."@en ;
+    skos:inScheme <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
+    skos:notation "11"^^dt:LocalHierarchyKey ;
+    skos:prefLabel "vacuum"@en ;
+    skos:topConceptOf <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> .
 
 
 <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/vibrocore> a skos:Concept ;

--- a/vocabularies/geosciml/boreholedrillingmethod.ttl
+++ b/vocabularies/geosciml/boreholedrillingmethod.ttl
@@ -182,7 +182,7 @@
     skos:definition "Mud rotary drilling is a method for wellbore excavation. It involves the use of a spinning drill bit aided by a semi-fluid mixture known as mud. Mud rotary drilling is adaptable for a wide range of trenchless construction situations, and is considered the most versatile and common of drilling methods."@en ;
     skos:inScheme <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
     skos:notation "3.2"^^dt:LocalHierarchyKey ;
-    skos:prefLabel "hydraulic rotary drilling"@en .
+    skos:prefLabel "mud rotary drilling"@en .
 
 
 <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/percussion_drilling> a skos:Concept ;


### PR DESCRIPTION
Addition of 3 Drilling Methods by the Geological Survey of Western Australia.

1. Coiled Tubing Drilling
2. Rotary Mud
3. Vacuum

A generic method of _rotary_ has also been added as a parent of the existing _Hydraulic Rotary Drilling_ and the new _Rotary Mud Drilling_.

All additions have definitions and sources.

After addition, the RDF has been validated using the VocPub profile validator (used for all CGI vocabs) at: http://rdftools.kurrawong.net/validate and it is valid.

This vocabulary, with these additions, is test presented online at http://20.248.147.246/vocab/boreholedrillingmethod
